### PR TITLE
Use context for cancel

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,23 @@
+---
+name: Test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test -v ./...

--- a/generator_test.go
+++ b/generator_test.go
@@ -1,0 +1,41 @@
+package datagen
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type message string
+
+func (m message) Serialize() ([]byte, error) {
+	return []byte(m), nil
+}
+
+func TestEngine_Run(t *testing.T) {
+	const ttl = 25
+	const step = 10
+	const ngen = 2
+	var want uint32 = (ttl / step) * ngen
+	var ops uint32
+
+	g := GeneratorFunc(func() Event {
+		time.Sleep(step * time.Millisecond)
+		return message("lorem ipsum")
+	})
+	p := PublisherFunc(func(b []byte) { atomic.AddUint32(&ops, 1) })
+
+	engine := NewEngine(g, p, WithNumGenerators(ngen), WithNumPublishers(ngen))
+	ctx, cancel := context.WithTimeout(context.Background(), ttl*time.Millisecond)
+	defer cancel()
+
+	engine.Run(ctx)
+	for _ = range ctx.Done() {
+		fmt.Println("waiting for end....")
+	}
+	if ops != want {
+		t.Errorf("engine not cancelled properly. got: %d, want: %d", ops, want)
+	}
+}


### PR DESCRIPTION
- Options no longer return an error as we are just setting values.
- Engine.Run() now requires a context to be used to control runtime execution.
- Generator signatures are updated to not include an error component.
- Tests were added.